### PR TITLE
Revised wan-up-since fix

### DIFF
--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -744,8 +744,8 @@ class PeplinkWANSensor(CoordinatorEntity, SensorEntity):
             
             # If we have uptime, calculate rounded value
             if current_uptime is not None:
-                # Round to nearest 5 minutes (300 seconds)
-                rounded_uptime = (current_uptime // 300) * 300
+                # Round to nearest 30 minutes (1800 seconds)
+                rounded_uptime = (current_uptime // 1800) * 1800
                 
                 # Only recalculate timestamp if rounded uptime changed
                 if rounded_uptime != self._cached_rounded_uptime:


### PR DESCRIPTION
The issue was that we were calling dt_util.utcnow() every time to recalculate the timestamp for comparison, which gave us a new "current time" on every call. Even though the uptime was the same, subtracting it from a different "now" time produced different results.

The solution caches the timestamp based on the rounded uptime value (to nearest 30 minutes):

  - When rounded uptime changes → recalculate timestamp once and cache it
  - When rounded uptime is unchanged → return the same cached datetime object

This prevents Home Assistant from seeing it as a state change.